### PR TITLE
Task / Update NodeCG to 0.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Out of the box, Twitchie will provide you with all of this:
 * Chat, via [tmi.js](https://tmijs.org/)
 * Emote (and cheermote) parsing from chat messages, including channel-specific emotes
 
+## Compatibility
+Twitchie requires that you use a version of NodeCG greater than *0.9*, and a version of node greater than *6.4.0*, because of some compatibility stuff.
+
 ## Usage
 
 Everything that Twitchie handles is exposed through NodeCG's replicants and bundle messages, in the `nodecg-twitchie` namespace. This means that getting stream information in your graphics is extra-simple!
@@ -44,6 +47,3 @@ You can also use Twitchie to query the Twitch API/access the tmi.js client direc
 In order to use Twitchie, you'll need to enable Twitch logins on your NodeCG instance, as we use this authentication to connect to the Twitch API and chat. Instructions on how to do this can be found in the [NodeCG documentation](http://nodecg.com/tutorial-nodecg-configuration.html).
 
 Please make sure you've included **user_read** and **chat_login** in your scopes!
-
-### Node Compatibility
-Please note that Twitchie requires you use a version of Node greater than *6.4.0*, because of some ES2016 compatibility stuff.

--- a/bower.json
+++ b/bower.json
@@ -2,13 +2,10 @@
   "name": "nodecg-twitchie",
   "version": "0.0.1",
   "dependencies": {
-    "paper-spinner": "^1.2.1",
-    "nodecg-replicant-input": "NodeCGElements/nodecg-replicant-input#0.4.0",
-    "iron-list": "^1.4.5",
-    "paper-item": "^1.2.2",
-    "iron-image": "^1.2.6",
-    "iron-pages": "^1.0.9",
-    "moment-element": "^0.4.4",
-    "moment": "~2.15.0"
+    "paper-spinner": "^2.1.0",
+    "iron-list": "^2.0.15",
+    "iron-image": "^2.2.1",
+    "nodecg-replicant-input": "NodeCGElements/nodecg-replicant-input#^1.0.1",
+    "moment": "~2.18.0"
   }
 }

--- a/common/constants.js
+++ b/common/constants.js
@@ -1,4 +1,4 @@
 module.exports = {
   NAMESPACE: 'nodecg-twitchie',
-  MAX_STORED_EVENTS: 100,
+  MAX_STORED_EVENTS: 50,
 }

--- a/common/events.js
+++ b/common/events.js
@@ -19,46 +19,35 @@ module.exports = (nodecg) => {
     emitter.emit(key, payload)
   }
 
-  const userId = nodecg.Replicant('user.id', NAMESPACE, {
+  const channelId = nodecg.Replicant('channel.id', NAMESPACE, {
     defaultValue: undefined,
     persistent: false,
   })
 
-  const allEvents = nodecg.Replicant('events', NAMESPACE, {
-    defaultValue: {},
+  const eventHistory = nodecg.Replicant('events', NAMESPACE, {
+    defaultValue: [],
     persistent: true,
   })
 
-  const currentChannelEvents = nodecg.Replicant('events.current', NAMESPACE, {
-    defaultValue: [],
-    persistent: false,
-  })
-
-  userId.on('change', (newValue) => {
-    currentChannelEvents.value = allEvents.value[newValue]
-  })
-
   emitter.addEvent = (subject, action, message) => {
-    const currentUser = userId.value
+    const channel = channelId.value
 
-    if (!currentUser) {
-      throw new Error('No user has been set to log events for')
+    if (!channel) {
+      throw new Error('No channel has been set to log events for')
     }
 
-    const eventStore = allEvents.value
-    const channelEvents = (eventStore[userId.value] || []).slice(0, MAX_STORED_EVENTS - 2)
+    const events = [ ...eventHistory.value ].slice(0, MAX_STORED_EVENTS - 2)
     const timestamp = Date.now()
 
-    channelEvents.unshift({
-      timestamp,
+    events.unshift({
       subject,
       action,
       message,
+      timestamp,
+      channel,
     })
 
-    eventStore[userId.value] = channelEvents
-    allEvents.value = eventStore
-    currentChannelEvents.value = channelEvents
+    eventHistory.value = events
   }
 
   return emitter

--- a/dashboard/channel.html
+++ b/dashboard/channel.html
@@ -2,23 +2,25 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <link rel="import" href="components/iron-image/iron-image.html">
-  <link rel="import" href="components/iron-pages/iron-pages.html">
-  <link rel="import" href="components/paper-spinner/paper-spinner.html">
-  <link rel="import" href="components/nodecg-replicant-input/nodecg-replicant-input.html">
+
+  <link rel="import" href="/bundles/nodecg-twitchie/bower_components/iron-image/iron-image.html">
+  <link rel="import" href="/bundles/nodecg-twitchie/bower_components/iron-pages/iron-pages.html">
+  <link rel="import" href="/bundles/nodecg-twitchie/bower_components/paper-spinner/paper-spinner.html">
+  <link rel="import" href="/bundles/nodecg-twitchie/bower_components/nodecg-replicant-input/nodecg-replicant-input.html">
 
   <style is="custom-style">
     #channel-field {
-      @apply(--layout-horizontal);
-      @apply(--layout-center);
+      display: flex;
+      align-items: center;
+
       margin: 0 auto 0.5em;
     }
 
     #logo {
-			width: 3em;
-			height: 3em;
+      width: 3em;
+      height: 3em;
       margin: 0 0 0 1em;
-			background-color: #ccc;
+      background-color: #ccc;
     }
 
     #info-page {
@@ -70,9 +72,8 @@
     }
 
     #stats {
-      @apply(--layout-horizontal);
-      @apply(--layout-center);
-      @apply(--layout-wrap);
+      display: flex;
+      flex-flow: row wrap;
       transition: 0.3s all ease-in-out;
     }
 
@@ -95,73 +96,62 @@
   </style>
 </head>
 <body>
-  <iron-pages id="login-pages" selected="channel" attr-for-selected="data-page-name">
-    <section data-page-name="login">
-      <h3>We've lost connection to Twitch!</h3>
+  <iron-pages selected="0">
+  <div>One</div>
+  <div>Two</div>
+  <div>Three</div>
+</iron-pages>
+  <section data-page-name="channel">
+    <div id="channel-field">
+      <nodecg-replicant-input
+        label="Channel ID"
+        replicant-name="channel.id"
+        replicant-bundle="nodecg-twitchie"
+      ></nodecg-replicant-input>
 
-      <p>
-        Please reconnect by logging in again.
+      <iron-image id="logo" sizing="contain" preload fade></iron-image>
+    </div>
+
+    <div data-page-name="error" id="error-page">
+      <p class="error-message" id="error-message">
+        We couldn't find any channels with that ID on Twitch.
       </p>
+    </div>
 
-      <a target="_parent" href="/login/twitch">
-        <img src="/login/signin_twitch.png" />
-      </a>
-    </section>
-
-    <section data-page-name="channel">
-      <div id="channel-field">
-        <nodecg-replicant-input
-          label="Channel ID"
-          replicant-name="channel.id"
-          replicant-bundle="nodecg-twitchie"
-        ></nodecg-replicant-input>
-
-        <iron-image id="logo" sizing="contain" preload fade></iron-image>
+    <div data-page-name="info" id="info-page">
+      <div id="loading">
+        <div class="loading__message">
+          <paper-spinner active class="loading__message-item"></paper-spinner>
+          <span class="loading__message-item">Retrieving channel info&hellip;</span>
+        </div>
       </div>
 
-      <iron-pages id="stats-pages" selected="info" attr-for-selected="data-page-name">
-        <div data-page-name="error">
-          <p class="error-message" id="error-message">
-            We couldn't find any channels with that ID on Twitch.
-          </p>
+      <div id="stats">
+        <div class="viewers stat">
+          <svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" x="0px" y="0px">
+            <path clip-rule="evenodd" d="M11,14H5H2v-1l3-3h2L5,8V2h6v6l-2,2h2l3,3v1H11z" fill-rule="evenodd"></path>
+          </svg>
+          <span id="stat.viewers">0</span>
         </div>
 
-        <div data-page-name="info" id="info-page">
-          <div id="loading">
-            <div class="loading__message">
-              <paper-spinner active class="loading__message-item"></paper-spinner>
-              <span class="loading__message-item">Retrieving channel info&hellip;</span>
-            </div>
-          </div>
-
-          <div id="stats">
-            <div class="viewers stat">
-              <svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" x="0px" y="0px">
-                <path clip-rule="evenodd" d="M11,14H5H2v-1l3-3h2L5,8V2h6v6l-2,2h2l3,3v1H11z" fill-rule="evenodd"></path>
-        			</svg>
-              <span id="stat.viewers">0</span>
-            </div>
-
-            <div class="followers stat">
-              <svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" x="0px" y="0px">
-                <path d="M8,13.5L1.5,7V4l2-2h3L8,3.5L9.5,2h3l2,2v3L8,13.5z" />
-        			</svg>
-              <span id="stat.followers">0</span>
-            </div>
-
-            <div class="timer full stat">
-              <svg height="18px" version="1.1" viewbox="0 0 18 18" width="18px" x="0px" y="0px">
-                <path clip-rule="evenodd" d="M15,14l-4-4v4H8.707l-0.5-0.5h-1L7.5,13.207V8.5h-5v4.707L2.793,13.5h-1l-0.5,0.5H1V4h10v4l4-4h2v10H15z M3,14h1l-1-1V9h1h2h1v4l-1,1h1h1l1,1v2H1v-2l1-1H3z" fill-rule="evenodd"></path>
-              </svg>
-              <span id="stat.timer">Offline</span>
-            </div>
-          </div>
+        <div class="followers stat">
+          <svg height="16px" version="1.1" viewBox="0 0 16 16" width="16px" x="0px" y="0px">
+            <path d="M8,13.5L1.5,7V4l2-2h3L8,3.5L9.5,2h3l2,2v3L8,13.5z" />
+          </svg>
+          <span id="stat.followers">0</span>
         </div>
-      </iron-pages>
-    </section>
-  </iron-pages>
 
-  <script src="components/moment/moment.js"></script>
+        <div class="timer full stat">
+          <svg height="18px" version="1.1" viewbox="0 0 18 18" width="18px" x="0px" y="0px">
+            <path clip-rule="evenodd" d="M15,14l-4-4v4H8.707l-0.5-0.5h-1L7.5,13.207V8.5h-5v4.707L2.793,13.5h-1l-0.5,0.5H1V4h10v4l4-4h2v10H15z M3,14h1l-1-1V9h1h2h1v4l-1,1h1h1l1,1v2H1v-2l1-1H3z" fill-rule="evenodd"></path>
+          </svg>
+          <span id="stat.timer">Offline</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script src="/bundles/nodecg-twitchie/bower_components/moment/moment.js"></script>
   <script src="scripts/verify-login.js"></script>
   <script src="scripts/channel-details.js"></script>
 </body>

--- a/dashboard/events.html
+++ b/dashboard/events.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
 
-  <link rel="import" href="components/iron-list/iron-list.html">
-  <link rel="import" href="components/paper-item/paper-item.html">
-  <link rel="import" href="components/moment-element/moment-element.html">
+  <link rel="import" href="/bundles/nodecg-twitchie/bower_components/iron-pages/iron-pages.html">
+  <link rel="import" href="/bundles/nodecg-twitchie/bower_components/iron-list/iron-list.html">
 
   <style>
     .event-list {
@@ -15,6 +14,12 @@
     .event {
       border-bottom: 0.075em solid #ccc;
       padding: 0.5em 0;
+      line-height: 1.2;
+
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: center;
+      justify-content: space-between;
     }
 
     .event:last-child {
@@ -37,9 +42,15 @@
       display: inline-block;
     }
 
-    .event__message {
+    .event__meta {
+      list-style-type: none;
+      margin: 0 0 0 0.5em;
       font-size: 0.85em;
-      line-height: 1.1;
+      text-align: center;
+    }
+
+    .event__channel {
+      margin-left: 0.5em;
     }
   </style>
 </head>
@@ -47,12 +58,8 @@
   <section>
     <iron-list items=[] id="eventList" as="event" class="event-list">
       <template>
-        <paper-item class="event">
-          <div class="event__timestamp">
-            <moment-element datetime="{{event.timestamp}}" output-format="HH:mm"></moment-element>
-          </div>
-
-          <paper-item-body two-line class="event__body">
+        <div class="event">
+          <div class="event__body">
             <header class="event__header">
               <div class="event__subject">[[event.subject]]</div>
               <div class="event__title">[[event.action]]</div>
@@ -61,13 +68,25 @@
             <div class="event__message">
               [[event.message]]
             </div>
-          </paper-item-body>
-        </paper-item>
+          </div>
+
+          <ul class="event__meta">
+            <li>
+              <strong>[[event.channel]]</strong>
+            </li>
+            <li>
+              <time>[[event.time]]</time>
+            </li>
+            <li>
+              <time>[[event.date]]</time>
+            </li>
+          </ul>
+        </div>
       </template>
     </iron-list>
   </section>
 
-  <script src="components/moment/moment.js"></script>
+  <script src="/bundles/nodecg-twitchie/bower_components/moment/moment.js"></script>
   <script src="scripts/events.js"></script>
 </body>
 </html>

--- a/dashboard/scripts/channel-details.js
+++ b/dashboard/scripts/channel-details.js
@@ -1,17 +1,17 @@
 /* global nodecg, moment */
 
-(() => {
+(async () => {
   const channelInfo = nodecg.Replicant('channel.info', 'nodecg-twitchie')
   const streamInfo = nodecg.Replicant('stream.info', 'nodecg-twitchie')
-  const loggedInStatus = nodecg.Replicant('login.status', 'nodecg-twitchie')
   const userInfo = nodecg.Replicant('user.info', 'nodecg-twitchie')
+
+  await NodeCG.waitForReplicants(channelInfo, streamInfo, userInfo)
 
   let streamStartedAt
 
   const elements = {
     pages: {
-      login: document.getElementById('login-pages'),
-      stats: document.getElementById('stats-pages'),
+      error: document.getElementById('error-page'),
       info: document.getElementById('info-page'),
     },
 
@@ -20,13 +20,6 @@
     followers: document.getElementById('stat.followers'),
     timer: document.getElementById('stat.timer'),
   }
-
-  loggedInStatus.on(
-    'change',
-    (isLoggedIn) => {
-      elements.pages.login.selected = isLoggedIn ? 'channel' : 'login'
-    }
-  )
 
   const tick = () => {
     let timerText
@@ -46,7 +39,9 @@
   userInfo.on(
     'change',
     ({ unknown = false, logo } = {}) => {
-      elements.pages.stats.selected = unknown ? 'error' : 'info'
+      elements.pages.error.style.display = unknown ? 'block' : 'none'
+      elements.pages.info.style.display = unknown ? 'none' : 'block'
+
       elements.logo.src = logo
     }
   )

--- a/dashboard/scripts/events.js
+++ b/dashboard/scripts/events.js
@@ -2,9 +2,19 @@
 
 (() => {
   const eventList = document.getElementById('eventList')
-  const channelEvents = nodecg.Replicant('events.current', 'nodecg-twitchie')
+  const events = nodecg.Replicant('events', 'nodecg-twitchie')
 
-  channelEvents.on('change', () => {
-    eventList.items = channelEvents.value || []
+  events.on('change', (newEvents) => {
+    const parsedEvents = (newEvents || [])
+      .map((item) => {
+        const newItem = Object.assign({}, item)
+        const eventDate = moment(item.timestamp)
+
+        newItem.time = eventDate.format('HH:mm')
+        newItem.date = eventDate.format('Do MMM')
+        return newItem
+      })
+
+    eventList.items = parsedEvents
   })
 })()

--- a/extension/api/identified-request.js
+++ b/extension/api/identified-request.js
@@ -24,9 +24,14 @@ const userLookupRequest = newChannelId =>
         return undefined
       }
 
+      const resolvedUser = users[0]
+
+      log.debug(`User ${newChannelId} resolved to ID ${resolvedUser._id}`)
+
       // eslint-disable-next-line no-underscore-dangle
-      user.id.value = users[0]._id
-      user.info.value = users[0]
+      user.id.value = resolvedUser._id
+      user.info.value = resolvedUser
+
       return user.id.value
     })
 

--- a/extension/modules/channel/poll.js
+++ b/extension/modules/channel/poll.js
@@ -31,9 +31,9 @@ const update = () => {
     fetchFollowers()
   ])
     .then(([info, followers]) => {
-      channel.info.value = info.channel
-      channel.followers.value = followers
-      stream.info.value = info.stream
+      channel.info.value = Object.assign({}, info.channel)
+      channel.followers.value = [ ...followers ]
+      stream.info.value = Object.assign({}, info.stream)
     }).catch((err) => {
       nodecg.log.error('Couldn\'t retrieve channel info :()', err)
     }).then(() => {
@@ -41,7 +41,7 @@ const update = () => {
     })
 }
 
-user.id.on('change', (newUserId) => {
+user.id.on('change', (newUserId, ...what) => {
   channel.info.value = undefined
   channel.followers.value = undefined
   stream.info.value = undefined

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nodecg-bundle"
   ],
   "nodecg": {
-    "compatibleRange": "~0.8.5",
+    "compatibleRange": ">=0.8.5",
     "dashboardPanels": [
       {
         "name": "twitch-channel",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nodecg-bundle"
   ],
   "nodecg": {
-    "compatibleRange": ">=0.8.5",
+    "compatibleRange": ">=0.9.0",
     "dashboardPanels": [
       {
         "name": "twitch-channel",


### PR DESCRIPTION
This PR updates Twitchie to work with versions of NodeCG greater than 0.9.0, in preparation for the 1.0 release sometime soon.

Various changes were made to the NodeCG dashboard—primarily, upgrading to Polymer 2—and underlying components that require breaking changes to bits of the bundle, so the NodeCG compatible range of Twitchie has been set to >=0.9 as part of this PR.